### PR TITLE
Update tmsvr_packet.py

### DIFF
--- a/techmanpy/packets/tmsvr_packet.py
+++ b/techmanpy/packets/tmsvr_packet.py
@@ -111,9 +111,13 @@ class TMSVR_packet(StatefulPacket):
    def _decode_value(self, value):
       if value == 'true': return True
       if value == 'false': return False
-      if '"' in value: return value[1:len(value)-1]
-      if '{' in value: return ast.literal_eval(value.replace('{', '[').replace('}', ']'))
-      return ast.literal_eval(value)
+      if '"' in value: return value[1:len(value)-1]         
+      value = value.replace('{', '[').replace('}', ']')
+      value = value.replace('true', 'True').replace('false', 'False') # ast.literal_eval will fail on 'false' and 'true'
+      try:
+         return ast.literal_eval(value)
+      except:
+         return value
 
    @property
    def ptype(self): return self._decode_data(self._data)[0]


### PR DESCRIPTION
The basic example of Subscribing to the broadcast crashed with cryptic error:
```
techmanpy\clients\stateful_client.py", line 42, in keep_alive
    await self._listen_task
ValueError: malformed node or string on line 1: <ast.Name object at 0x000001E9C3FD4A90>
```

*The example*
```def on_params(params):
   # broadcasted parameters received
   ...

conn.add_broadcast_callback(on_params)
await conn.keep_alive()
```

It crashes because ast.literal_eval will fail on the 'false' and 'true' values in the broadcast. I've added a .replace to make capitalize them. I've also added a try except to just give the raw value if conversion fails.

The value causing the crash in my case was:
```
SO_OSSD {false,false,false,false,false,false,false,false}
```